### PR TITLE
Fix code scanning alert no. 12: Resolving XML external entity in user-controlled data

### DIFF
--- a/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParser.java
+++ b/platforms/software/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParser.java
@@ -1345,24 +1345,23 @@ public class IvyXmlModuleDescriptorParser extends AbstractModuleDescriptorParser
 
         private static SAXParser newSAXParser(URL schema, InputStream schemaStream)
                 throws ParserConfigurationException, SAXException {
-            if (schema == null) {
-                SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
-                parserFactory.setValidating(false);
-                parserFactory.setNamespaceAware(true);
-                SAXParser parser = parserFactory.newSAXParser();
-                parser.getXMLReader().setFeature(XML_NAMESPACE_PREFIXES, true);
-                return parser;
-            } else {
-                SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
-                parserFactory.setValidating(true);
-                parserFactory.setNamespaceAware(true);
+            SAXParserFactory parserFactory = XmlFactories.newSAXParserFactory();
+            parserFactory.setNamespaceAware(true);
+            parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
 
-                SAXParser parser = parserFactory.newSAXParser();
+            if (schema != null) {
+                parserFactory.setValidating(true);
+            }
+
+            SAXParser parser = parserFactory.newSAXParser();
+            if (schema != null) {
                 parser.setProperty(JAXP_SCHEMA_LANGUAGE, W3C_XML_SCHEMA);
                 parser.setProperty(JAXP_SCHEMA_SOURCE, schemaStream);
-                parser.getXMLReader().setFeature(XML_NAMESPACE_PREFIXES, true);
-                return parser;
             }
+            parser.getXMLReader().setFeature(XML_NAMESPACE_PREFIXES, true);
+            return parser;
         }
 
         public static void parse(


### PR DESCRIPTION
Fixes [https://github.com/MrG9090/Noo/security/code-scanning/12](https://github.com/MrG9090/Noo/security/code-scanning/12)

To fix the problem, we need to configure the `SAXParserFactory` to disable external entity resolution. This can be done by setting specific features on the `SAXParserFactory` and the `SAXParser` to prevent the parsing of external entities and DTDs.

- Modify the `newSAXParser` method to set the necessary features on the `SAXParserFactory` and the `SAXParser`.
- Ensure that the `SAXParser` is configured to disallow DOCTYPE declarations and external entities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
